### PR TITLE
feat(ui): Add `is_scratch_buffer` flag to scratch buffers

### DIFF
--- a/lua/quick-scratch/ui.lua
+++ b/lua/quick-scratch/ui.lua
@@ -198,6 +198,7 @@ function M.spawn_float_window(scratch_path, window_opts, buffer_pos)
 	local buf_id = vim.api.nvim_create_buf(false, false)
 	vim.api.nvim_buf_set_name(buf_id, scratch_path)
 	vim.api.nvim_buf_set_lines(buf_id, 0, -1, false, file_lines)
+	vim.api.nvim_buf_set_var(buf_id, "is_scratch_buffer", true)
 
 	-- Trigger filetype detection on that buffer, so syntax highlighting works
 	-- The view stuff is to get around other plugins intercepting the commands and attempting to


### PR DESCRIPTION
## Description
<!-- What does this pull request do? -->
This pull request simply adds a new flag to the created scratch buffers that says if they're a scratch buffer or not. This can be accessed like so:
```lua
local is_scratch_buffer = vim.fn.getbufvar(opts.buf, "is_scratch_buffer") == true
if not is_scratch_buffer then
    require("lint").try_lint()
    vim.cmd(":FormatWrite")
end
```

This exists due to running into edge-cases where if you have an autocmd for `BufWritePost` going and something that runs on those buffers, you can tell it not to do so for scratch ones.

